### PR TITLE
typo in `clock_adequacy_example` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Next, we set the directory to example_run_and_results, and run the function adeq
 
 ```coffee
 setwd("../example_run_and_results")
-clock_adequacy_example <- adeq(trees.file = "sim.trees", sim.log ="sim.log", empdat.file = "al.nex", Nsim = 100)
+clock_adequacy_example <- adeq(trees.file = "sim.trees", log.file = "sim.log", empdat.file = "al.nex", Nsim = 100)
 names(clock_adequacy_example)
 ```
 


### PR DESCRIPTION
The existing command:
```
clock_adequacy_example <- adeq(trees.file = "sim.trees", sim.log ="sim.log", empdat.file = "al.nex", Nsim = 100)
```
does not work because `sim.log` is not a valid argument. The correct argument is `log.file`. So replace with:
```
clock_adequacy_example <- adeq(trees.file = "sim.trees", log.file = "sim.log", empdat.file = "al.nex", Nsim = 100)
```
HTH.
JWB